### PR TITLE
Increase desktop logo size

### DIFF
--- a/style.css
+++ b/style.css
@@ -69,6 +69,12 @@ header {
   width: auto;
 }
 
+@media (min-width: 769px) {
+  .logo img {
+    height: 60px;
+  }
+}
+
 @media (max-width: 768px) {
   .logo.hidden {
     display: none;
@@ -118,6 +124,12 @@ nav a:hover {
   justify-content: center;
   text-align: center;
   padding-top: 60px; /* space for fixed header */
+}
+
+@media (min-width: 769px) {
+  .hero {
+    padding-top: 80px; /* more space for larger desktop header */
+  }
 }
 
 /* Hero background image styling */


### PR DESCRIPTION
## Summary
- enlarge the logo for desktop displays
- add extra top padding to hero section when viewed on desktop so header doesn't cover content

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888816061a08320871a267425ea92a6